### PR TITLE
Make transactions with up to 16 OP_RETURN that are up to 512 bytes standard

### DIFF
--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -442,7 +442,7 @@ Relay and mine data carrier transactions (default: 1)
 \fB\-datacarriersize\fR
 .IP
 Maximum size of data in data carrier transactions we relay and mine
-(default: 83)
+(default: 516)
 .HP
 \fB\-mempoolreplacement\fR
 .IP

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -447,7 +447,7 @@ Relay and mine data carrier transactions (default: 1)
 \fB\-datacarriersize\fR
 .IP
 Maximum size of data in data carrier transactions we relay and mine
-(default: 83)
+(default: 516)
 .HP
 \fB\-mempoolreplacement\fR
 .IP

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -132,7 +132,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
     }
 
     // only one OP_RETURN txout is permitted
-    if (nDataOut > 1) {
+    if (nDataOut > 16) {
         reason = "multi-op-return";
         return false;
     }

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -28,10 +28,10 @@ public:
 };
 
 /**
- * Default setting for nMaxDatacarrierBytes. 80 bytes of data, +1 for OP_RETURN,
- * +2 for the pushdata opcodes.
+ * Default setting for nMaxDatacarrierBytes. 512 bytes of data, +1 for OP_RETURN,
+ * +3 for the pushdata opcodes.
  */
-static const unsigned int MAX_OP_RETURN_RELAY = 83;
+static const unsigned int MAX_OP_RETURN_RELAY = 516;
 
 /**
  * A data carrying output is an unspendable output containing data. The script


### PR DESCRIPTION
..., that is enable their relaying by default.

As we tested and arranged before, this change won't require a soft fork and we already mine such transactions - they just need to be enabled network-wide.