### PR TITLE
Name the testsuite Susucoin.

### DIFF
--- a/src/test/test_susucoin_main.cpp
+++ b/src/test/test_susucoin_main.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#define BOOST_TEST_MODULE Bitcoin Test Suite
+#define BOOST_TEST_MODULE Susucoin Test Suite
 
 #include <net.h>
 


### PR DESCRIPTION
The test suite is now called Susucoin and not Bitcoin.