### PR TITLE
Move the ECC setup and tear down into it's own globar RAII object

### DIFF
--- a/src/test/test_susucoin.cpp
+++ b/src/test/test_susucoin.cpp
@@ -18,6 +18,16 @@
 #include <rpc/register.h>
 #include <script/sigcache.h>
 
+/*
+ * Move the ECC setup and tear down into it's own globar RAII object.
+ * This fixes a lot of memory reference errors on OS X, at least.
+ */
+class CEccSetup {
+public:
+	CEccSetup() { ECC_Start(); }
+	~CEccSetup() { ECC_Stop(); }
+} eccSetup;
+
 void CConnmanTest::AddNode(CNode& node)
 {
     LOCK(g_connman->cs_vNodes);
@@ -49,7 +59,6 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 {
         SHA256AutoDetect();
         RandomInit();
-        ECC_Start();
         SetupEnvironment();
         SetupNetworking();
         InitSignatureCache();
@@ -61,7 +70,6 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 
 BasicTestingSetup::~BasicTestingSetup()
 {
-        ECC_Stop();
 }
 
 TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)


### PR DESCRIPTION
The test suite crashes and burns because the ECC library is set up and torn down many time.

This pull request puts the initialization and tear down functions into a global RAII object so it only happens once, even when the test suite is setup and torn down multiple times.

This smells of a bug somewhere else, but this is a neat workaround.