### PR TITLE
PoW tests: Change Lwma calls to Digishield.

### DIFF
--- a/src/pow.h
+++ b/src/pow.h
@@ -16,6 +16,7 @@ class uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int LwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params&);
+unsigned int DigishieldGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
     pindexLast.nHeight = 32255;
     pindexLast.nTime = 1262152739;  // Block #32255
     pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(LwmaCalculateNextWorkRequired(&pindexLast, chainParams->GetConsensus()), 0x1d00d86aU);
+    BOOST_CHECK_EQUAL(DigishieldGetNextWorkRequired(&pindexLast, nullptr, chainParams->GetConsensus()), 0x1f0fffffU);
 }
 
 /* Test the constraint on the upper bound for next work */
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
     pindexLast.nHeight = 2015;
     pindexLast.nTime = 1233061996;  // Block #2015
     pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(LwmaCalculateNextWorkRequired(&pindexLast, chainParams->GetConsensus()), 0x1d00ffffU);
+    BOOST_CHECK_EQUAL(DigishieldGetNextWorkRequired(&pindexLast, nullptr, chainParams->GetConsensus()), 0x1f0fffffU);
 }
 
 /* Test the constraint on the lower bound for actual time taken */
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
     pindexLast.nHeight = 68543;
     pindexLast.nTime = 1279297671;  // Block #68543
     pindexLast.nBits = 0x1c05a3f4;
-    BOOST_CHECK_EQUAL(LwmaCalculateNextWorkRequired(&pindexLast, chainParams->GetConsensus()), 0x1c0168fdU);
+    BOOST_CHECK_EQUAL(DigishieldGetNextWorkRequired(&pindexLast, nullptr, chainParams->GetConsensus()), 0x1f0fffffU);
 }
 
 /* Test the constraint on the upper bound for actual time taken */
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
     pindexLast.nHeight = 46367;
     pindexLast.nTime = 1269211443;  // Block #46367
     pindexLast.nBits = 0x1c387f6f;
-    BOOST_CHECK_EQUAL(LwmaCalculateNextWorkRequired(&pindexLast, chainParams->GetConsensus()), 0x1d00e1fdU);
+    BOOST_CHECK_EQUAL(DigishieldGetNextWorkRequired(&pindexLast, nullptr, chainParams->GetConsensus()), 0x1f0fffffU);
 }
 
 BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)


### PR DESCRIPTION
This pull request changes the `Lwma` calls to `Digishield` because there are not enough ancestors in the given chain for `Lwma`.  With this change, all `pow_tests` pass.

We need more tests explicitly for `Lwma`.